### PR TITLE
feat: rough migration to fastcrud

### DIFF
--- a/api/crud.py
+++ b/api/crud.py
@@ -1,0 +1,4 @@
+from fastcrud import FastCRUD
+from models.user import User
+
+crud_user = FastCRUD(User)

--- a/api/deps.py
+++ b/api/deps.py
@@ -14,6 +14,7 @@ from fastapi.security import OAuth2PasswordBearer
 from fastapi import Depends, HTTPException
 from models.generic import TokenPayload
 from models.user import User
+from .crud import crud_user
 
 from sqlmodel import Session
 
@@ -40,7 +41,7 @@ def get_current_user(session: SessionDep, token: TokenDep) -> User:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Could not validate credentials",
         )
-    user = session.get(User, token_data.sub)
+    user = crud_user.get(session, id=token_data.sub)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     if not user.is_active:

--- a/api/login.py
+++ b/api/login.py
@@ -5,10 +5,11 @@ from config import ACCESS_TOKEN_EXPIRE_MINUTES
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from models.generic import Token
-from models.user import UserPublic, User
+from models.user import UserPublic
 from models import security
 from .deps import CurrentUser, SessionDep
 from models.security import verify_password
+from .crud import crud_user
 
 router = APIRouter()
 
@@ -20,7 +21,7 @@ def login_access_token(
     """
     OAuth2 compatible token login, get an access token for future requests
     """
-    user = User.by_email(session, email=form_data.username)
+    user = crud_user.get_by(session, email=form_data.username)
     if user is None or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
     elif not user.is_active:

--- a/models/user.py
+++ b/models/user.py
@@ -1,10 +1,8 @@
 import uuid
-from typing import Self
 
 from pydantic import EmailStr
 
-from models.security import get_password_hash
-from sqlmodel import Field, SQLModel, select, Session
+from sqlmodel import Field, SQLModel
 
 
 # Shared properties
@@ -56,17 +54,3 @@ class UpdatePassword(SQLModel):
 class User(UserBase, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     hashed_password: str
-
-    @classmethod
-    def create(cls, session: Session, user_create: UserCreate) -> Self:
-        db_obj = cls.model_validate(
-            user_create, update={"hashed_password": get_password_hash(user_create.password)}
-        )
-        session.add(db_obj)
-        return db_obj
-
-    @classmethod
-    def by_email(cls, session: Session, email: EmailStr) -> Self | None:
-        statement = select(cls).where(cls.email == email)
-        session_user = session.exec(statement).first()
-        return session_user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
     "sqlmodel>=0.0.22",
+    "fastcrud>=0.11.3",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- add fastcrud dependency
- start migrating user model and routes to FastCRUD
- centralize FastCRUD usage in api package to cut boilerplate

## Testing
- `ruff check` *(fails: E402, F401, F841 across repository)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689b4995cb9c8321b041ec1f684c4ff2